### PR TITLE
Discards cards EasyAI pull from draw pile

### DIFF
--- a/src/main/java/biblioteket/roborally/actors/EasyAI.java
+++ b/src/main/java/biblioteket/roborally/actors/EasyAI.java
@@ -19,7 +19,7 @@ public class EasyAI extends Actor implements INonPlayer {
         while (!super.fullProgramRegister()) {
             int id = new Random().nextInt(cards.size());
             super.addCardToProgramRegister(cards.get(id), deck);
-            cards.remove(id);
+            deck.addToDiscardPile(cards.remove(id));
         }
     }
 }

--- a/src/main/java/biblioteket/roborally/programcards/ICardDeck.java
+++ b/src/main/java/biblioteket/roborally/programcards/ICardDeck.java
@@ -7,6 +7,8 @@ public interface ICardDeck {
     /**
      * Get as many cards as specified,
      * from the conceptual "top of the draw pile".
+     * OBS - Remember to place cards in discard pile afterwards.
+     * Otherwise will the deck empty itself.
      *
      * @param number how many cards to draw.
      * @return list with as many cards as specified.


### PR DESCRIPTION
EasyAI now discards cards, which should fix the issue of the draw pile being empty.
Closes #136 